### PR TITLE
feat: implement binance websocket fetcher

### DIFF
--- a/packages/oracle-node/manifests/data-services/binance-ws.json
+++ b/packages/oracle-node/manifests/data-services/binance-ws.json
@@ -1,0 +1,42 @@
+{
+  "interval": 10000,
+  "priceAggregator": "median",
+  "defaultSource": [
+    "binance-ws"
+  ],
+  "sourceTimeout": 7000,
+  "minValidSourcesPercentage": 1,
+  "deviationCheck": {
+    "deviationWithRecentValues": {
+      "maxPercent": 30,
+      "maxDelayMilliseconds": 300000
+    }
+  },
+  "tokens": {
+    "USDC": {
+      "source": [
+        "binance-ws"
+      ]
+    },
+    "BTC": {
+      "source": [
+        "binance-ws"
+      ]
+    },
+    "ETH": {
+      "source": [
+        "binance-ws"
+      ]
+    },
+    "SOL": {
+      "source": [
+        "binance-ws"
+      ]
+    },
+    "AR": {
+      "source": [
+        "binance-ws"
+      ]
+    }
+  }
+}

--- a/packages/oracle-node/manifests/data-services/primary.json
+++ b/packages/oracle-node/manifests/data-services/primary.json
@@ -17,6 +17,7 @@
     "USDC": {
       "source": [
         "binance",
+        "binance-ws",
         "binanceusdm",
         "bitfinex2",
         "bitget",
@@ -89,6 +90,7 @@
         "ascendex",
         "bequant",
         "binance",
+        "binance-ws",
         "binancecoinm",
         "binanceusdm",
         "bingx",
@@ -183,6 +185,7 @@
       "source": [
         "ascendex",
         "binance",
+        "binance-ws",
         "binancecoinm",
         "binanceusdm",
         "bitcoincom",

--- a/packages/oracle-node/package.json
+++ b/packages/oracle-node/package.json
@@ -67,6 +67,7 @@
     "redstone-api": "^0.4.11",
     "sort-deep-object-arrays": "^1.1.2",
     "uuid": "^9.0.0",
+    "ws": "^8.18.0",
     "yahoo-finance2": "^2.4.2",
     "zod": "^3.22.2"
   },
@@ -82,6 +83,7 @@
     "@types/prompts": "^2.4.2",
     "@types/supertest": "^2.0.12",
     "@types/uuid": "^8.3.0",
+    "@types/ws": "^8.5.12",
     "ar-gql": "^0.0.11",
     "copyfiles": "^2.4.1",
     "dateformat": "^4.5.1",

--- a/packages/oracle-node/src/config.ts
+++ b/packages/oracle-node/src/config.ts
@@ -66,6 +66,8 @@ const DEFAULT_OPTIMISM_RPC_URLS = [
 ];
 const DEFAULT_HISTORICAL_DATA_PACKAGES_URL =
   "https://oracle-gateway-1.b.redstone.finance";
+const DEFAULT_BINANCE_WEBSOCKET_API_URL =
+  "wss://testnet.binance.vision/ws-api/v3";
 
 const getFromEnv = (envName: string, defaultValue?: string): string => {
   const valueFromEnv = process.env[envName];
@@ -272,5 +274,9 @@ export const config: NodeConfig = Object.freeze({
       "AGREEMENT_PROVIDER_SINGLE_RPC_TIMEOUT",
       DEFAULT_AGREEMENT_PROVIDER_SINGLE_RPC_TIMEOUT
     )
+  ),
+  binanceWebsocketApiUrl: getFromEnv(
+    "BINANCE_WEBSOCKET_API_URL",
+    DEFAULT_BINANCE_WEBSOCKET_API_URL
   ),
 });

--- a/packages/oracle-node/src/fetchers/WebSocketClient.ts
+++ b/packages/oracle-node/src/fetchers/WebSocketClient.ts
@@ -1,0 +1,110 @@
+import WebSocket from "ws";
+
+export type WebSocketMessage = Buffer | ArrayBuffer | Buffer[];
+
+export type OnWebSocketMessage = (data: WebSocketMessage) => void;
+export type OnWebSocketError = (error: Error) => void;
+export type OnWebSocketClose = (code: number, reason: string) => void;
+
+export interface WebSocketEvents {
+  onMessage?: OnWebSocketMessage;
+  onError?: OnWebSocketError;
+  onClose?: OnWebSocketClose;
+}
+
+export interface WebsocketOptions {
+  maxConnectionTimeMs?: number;
+  canRestartConnection?: () => boolean;
+}
+
+const CONNECTION_CLOSE_RETRY_AFTER_MS = 1000;
+
+export class WebSocketClient {
+  private readonly url: string;
+  private readonly events: WebSocketEvents;
+  private ws: WebSocket | null = null;
+  private options: WebsocketOptions;
+  private restartConnectionTimeout: NodeJS.Timeout | null = null;
+
+  constructor(
+    url: string,
+    events: WebSocketEvents,
+    options: WebsocketOptions = {}
+  ) {
+    this.url = url;
+    this.events = events;
+    this.options = options;
+  }
+
+  public async send(data: string): Promise<void> {
+    const ws = await this.getConnection();
+    ws.send(data);
+  }
+
+  private connect(): Promise<WebSocket> {
+    return new Promise((resolve) => {
+      const ws = new WebSocket(this.url);
+      ws.on("error", (e) => {
+        if (this.events.onError) {
+          this.events.onError(e);
+        }
+      });
+
+      ws.on("open", () => {
+        if (this.options.maxConnectionTimeMs) {
+          this.restartConnectionTimeout = setTimeout(() => {
+            this.safelyCloseConnection();
+          }, this.options.maxConnectionTimeMs);
+        }
+
+        resolve(ws);
+      });
+
+      ws.on("message", (data) => {
+        if (this.events.onMessage) {
+          this.events.onMessage(data);
+        }
+      });
+
+      ws.on("close", (code, reason) => {
+        this.cleanupConnection();
+        if (this.events.onClose) {
+          this.events.onClose(code, reason.toString());
+        }
+      });
+    });
+  }
+
+  // This function closes connection only if parent agrees to it (e.g. if there are pending requests). Closing is delayed otherwise.
+  private safelyCloseConnection() {
+    const canClose = this.options.canRestartConnection
+      ? this.options.canRestartConnection()
+      : false;
+
+    if (canClose) {
+      this.ws?.close();
+    } else {
+      this.restartConnectionTimeout = setTimeout(() => {
+        this.safelyCloseConnection();
+      }, CONNECTION_CLOSE_RETRY_AFTER_MS);
+    }
+  }
+
+  private cleanupConnection() {
+    this.ws = null;
+
+    if (this.restartConnectionTimeout) {
+      clearTimeout(this.restartConnectionTimeout);
+    }
+  }
+
+  private async getConnection(): Promise<WebSocket> {
+    if (this.ws) {
+      return this.ws;
+    }
+
+    this.ws = await this.connect();
+
+    return this.ws;
+  }
+}

--- a/packages/oracle-node/src/fetchers/binance/BinanceClient.ts
+++ b/packages/oracle-node/src/fetchers/binance/BinanceClient.ts
@@ -1,0 +1,134 @@
+import { v4 as uuidv4 } from "uuid";
+import { WebSocketClient, WebSocketMessage } from "../WebSocketClient";
+import { config } from "../../config";
+
+export interface BinanceRequest {
+  id: string;
+  method: string;
+  params: {
+    symbols: string[];
+  };
+}
+
+interface BinanceResponse {
+  id: string;
+  status: number;
+  result: unknown;
+}
+
+export interface BinanceTickersResponse extends BinanceResponse {
+  result: {
+    symbol: string;
+    price: number;
+  }[];
+}
+
+type PendingRequests = {
+  [key: string]: {
+    onSuccess: (response: BinanceResponse) => void;
+    onError: (error: Error) => void;
+    timeout: NodeJS.Timeout;
+  };
+};
+
+const REQUEST_TIMEOUT_MS = 5000;
+
+export class BinanceClient {
+  private client: WebSocketClient = new WebSocketClient(
+    config.binanceWebsocketApiUrl,
+    {
+      onMessage: this.onMessage.bind(this),
+      onClose: this.onClose.bind(this),
+      onError: this.onError.bind(this),
+    },
+    {
+      maxConnectionTimeMs: 1000 * 60 * 10,
+      canRestartConnection: () => Object.keys(this.requests).length <= 0,
+    }
+  );
+  private requests: PendingRequests = {};
+
+  public fetchTickers(ids: string[]): Promise<BinanceTickersResponse> {
+    return this.sendRequest<BinanceTickersResponse>({
+      method: "ticker.price",
+      params: {
+        symbols: ids,
+      },
+    });
+  }
+
+  private onMessage(data: WebSocketMessage) {
+    try {
+      const response: BinanceResponse = JSON.parse(
+        // eslint-disable-next-line @typescript-eslint/no-base-to-string
+        data.toString()
+      ) as BinanceResponse;
+
+      if (!(response.id in this.requests)) {
+        console.warn(
+          "Received WebSocket message but no matching response listeners were found."
+        );
+        return;
+      }
+
+      this.requests[response.id].onSuccess(response);
+      delete this.requests[response.id];
+    } catch (e) {
+      console.error("Could not process incoming Binance message: ", e);
+    }
+  }
+
+  private onError(error: Error) {
+    for (const requestId in this.requests) {
+      const request = this.requests[requestId];
+      request.onError(
+        new Error(`Binance request ${requestId} failed: ${error.message}`)
+      );
+      delete this.requests[requestId];
+    }
+  }
+
+  private onClose(code: number, reason: string) {
+    for (const requestId in this.requests) {
+      const request = this.requests[requestId];
+      request.onError(
+        new Error(
+          `Binance request ${requestId} failed because WebSocket connection was closed. Code: ${code}. Reason: ${reason}`
+        )
+      );
+      delete this.requests[requestId];
+    }
+  }
+
+  private sendRequest<T extends BinanceResponse>(
+    request: Omit<BinanceRequest, "id">
+  ): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const reqId = uuidv4();
+
+      const req: BinanceRequest = {
+        id: reqId,
+        ...request,
+      };
+
+      this.requests[reqId] = {
+        onSuccess: (result) => {
+          clearTimeout(this.requests[reqId].timeout);
+          resolve(result as T);
+        },
+        onError: (error: Error) => {
+          clearTimeout(this.requests[reqId].timeout);
+          reject(error);
+        },
+        timeout: setTimeout(() => {
+          if (reqId in this.requests) {
+            reject("Request timeout.");
+            delete this.requests[reqId];
+          }
+        }, REQUEST_TIMEOUT_MS),
+      };
+
+      void this.client.send(JSON.stringify(req));
+    });
+  }
+}

--- a/packages/oracle-node/src/fetchers/binance/BinanceFetcher.ts
+++ b/packages/oracle-node/src/fetchers/binance/BinanceFetcher.ts
@@ -1,0 +1,38 @@
+import { BaseFetcher } from "../BaseFetcher";
+import { PricesObj } from "../../types";
+import { BinanceClient, BinanceTickersResponse } from "./BinanceClient";
+
+const SYMBOL_SUFFIX = "USDT";
+
+export class BinanceFetcher extends BaseFetcher {
+  private client = new BinanceClient();
+
+  constructor() {
+    super("binance-ws");
+  }
+
+  override convertIdToSymbol(id: string) {
+    return id.substring(0, id.length - SYMBOL_SUFFIX.length);
+  }
+
+  override convertSymbolToId(symbol: string) {
+    return `${symbol}${SYMBOL_SUFFIX}`;
+  }
+
+  override validateResponse(
+    response: BinanceTickersResponse | undefined
+  ): boolean {
+    return !(response === undefined || response.status != 200);
+  }
+
+  override async fetchData(ids: string[]): Promise<BinanceTickersResponse> {
+    return await this.client.fetchTickers(ids);
+  }
+
+  override extractPrices(res: BinanceTickersResponse): PricesObj {
+    return this.extractPricesSafely(res.result, (item) => ({
+      value: item.price,
+      id: item.symbol,
+    }));
+  }
+}

--- a/packages/oracle-node/src/fetchers/binance/example-response.json
+++ b/packages/oracle-node/src/fetchers/binance/example-response.json
@@ -1,0 +1,18 @@
+{
+  "id": "",
+  "status": 200,
+  "result": [
+    {
+      "symbol": "BTCUSDT",
+      "price": 38190
+    },
+    {
+      "symbol": "ETHUSDT",
+      "price": 2704.39
+    },
+    {
+      "symbol": "ARUSDT",
+      "price": 17.46
+    }
+  ]
+}

--- a/packages/oracle-node/src/fetchers/index.ts
+++ b/packages/oracle-node/src/fetchers/index.ts
@@ -43,8 +43,10 @@ import { camelotV3Fetchers } from "./evm-chain/arbitrum/camelot-v3/all-camelot-v
 import pancakeSwapFetchers from "./evm-chain/ethereum/pancake-swap-on-chain/all-pancake-swap-fetchers";
 import { WombatFetcher } from "./wombat/WombatFetcher";
 import { apiFetchers } from "./api-fetcher/all-api-fetchers";
+import { BinanceFetcher } from "./binance/BinanceFetcher";
 
 export default {
+  "binance-ws": new BinanceFetcher(),
   "yf-unofficial": new YfUnofficialFetcher(),
   "custom-urls": new CustomUrlsFetcher(),
   mock: new MockFetcher(),

--- a/packages/oracle-node/src/types.ts
+++ b/packages/oracle-node/src/types.ts
@@ -195,6 +195,7 @@ export interface NodeConfig {
   dockerImageTag: string;
   agreementProvidersTimeout: number;
   agreementProviderSingleRpcTimeout: number;
+  binanceWebsocketApiUrl: string;
 }
 
 export interface MulticallRequest {

--- a/packages/oracle-node/test/fetchers/binance.spec.ts
+++ b/packages/oracle-node/test/fetchers/binance.spec.ts
@@ -1,0 +1,43 @@
+process.env.BINANCE_WEBSOCKET_API_URL = "ws://localhost:1234"; // must be called before imports to override API URL
+
+import fetchers from "../../src/fetchers/index";
+import {
+  BinanceRequest,
+  BinanceTickersResponse,
+} from "../../src/fetchers/binance/BinanceClient";
+import { mockWsFetcherResponse } from "./_helpers";
+
+mockWsFetcherResponse<BinanceRequest, BinanceTickersResponse>(
+  1234,
+  (request: BinanceRequest) => {
+    const response =
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      require("../../src/fetchers/binance/example-response.json") as BinanceTickersResponse;
+    response.id = request.id;
+
+    return response;
+  }
+);
+
+describe("binance fetcher", () => {
+  const sut = fetchers["binance-ws"]!;
+
+  it("should properly fetch data", async () => {
+    const result = await sut.fetchAll(["BTC", "ETH", "AR"]);
+
+    expect(result).toEqual([
+      {
+        symbol: "BTC",
+        value: 38190,
+      },
+      {
+        symbol: "ETH",
+        value: 2704.39,
+      },
+      {
+        symbol: "AR",
+        value: 17.46,
+      },
+    ]);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -6104,6 +6104,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/ws@^8.5.12":
+  version "8.5.12"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.12.tgz#619475fe98f35ccca2a2f6c137702d85ec247b7e"
+  integrity sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/yargs-parser@*":
   version "21.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"
@@ -19639,6 +19646,11 @@ ws@^7.4.5, ws@^7.4.6, ws@^7.5.0:
   version "7.5.9"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
   integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
+
+ws@^8.18.0:
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
+  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
 
 ws@^8.5.0, ws@^8.8.1:
   version "8.13.0"


### PR DESCRIPTION
# Testing

There are 3 ways of testing the solution.

### Mocked unit test

1. Clone repo, install dependencies, populate .env file and build.
2. Go to `./packages/oracle-node` directory.
3. Run `yarn test test/fetchers/binance.spec.ts`.

### Unmocked unit test

1. Clone repo, install dependencies, populate .env file and build.
2. Open `./package/oracle-node/test/fetchers/binance.spec.ts`.
 - Replace `ws://localhost:1234` with `wss://testnet.binance.vision/ws-api/v3`
 - Comment-out `mockWsFetcherResponse` function call.
3. Go to `./packages/oracle-node` directory.
4. Run `yarn test test/fetchers/binance.spec.ts`.

Test assertions will obviously fail because they fetch live Binance Testnet data, however it proves that code works.

### Running the app

1. Clone repo, install dependencies, populate .env file and build.
2. Set `OVERRIDE_MANIFEST_USING_FILE` variable in .env file to `./manifests/data-services/binance-ws.json`
3. Go to `./packages/oracle-node` directory.
4. Run `yarn start:dev` and inspect logs in `./packages/oracle-node/tmp.out`.

# Binance API rate limiting

Binance API allow for:
- 6000 request weight per minute
- 50 orders per 10 seconds
- 160000 per 24 hours

Considering 1 request every 10 seconds (as in primary manifest.json - but main.json has even lower frequency) we use:
- 24 request weight per minute (6 requests * 4 weight per ticker.price method)
- 2 request weight every 10 hours to establish connection (negligible)
- 1 order per 10 seconds
- 8640 orders per 24h

Looks like we are way below the limits so we should be safe there.

# Code architecture notes

After first reading the task's description and taking a first glance at the code, I thought it is implied to create another abstract class like `BaseFetcher` but for WebSockets and use it for Binance fetcher. I quickly dropped this idea, mostly because `BaseFetcher` is actually protocol-agnostic so it's a good abstraction for WebSocket fetchers as well.

As a next step, I tried to split the actual fetcher responsibilities to classes and ended up with 3:
- `WebSocketClient` - minimalistic, API-agnostic
- `BinanceClient` - uses WebSocketClient and fetches the data we need from the API but doesn't know anything about the rest of the application
- BinanceFetcher - uses BinanceClient and inherits from BaseFetcher

In relations between those classes I went with composition instead of inheritance because it is preferred to be able to unit-test them separately, however I didn't prepare unit tests for `WebSocketClient` and `BinanceClient` to keep the coding task in reasonable time constraints.