### PR TITLE
Websocket Fetcher with example of implementation new fetcher for binance

### DIFF
--- a/packages/oracle-node/manifests/data-services/main.json
+++ b/packages/oracle-node/manifests/data-services/main.json
@@ -54,6 +54,7 @@
         "ascendex",
         "band",
         "bequant",
+        "binance-websoket",
         "binance",
         "binancecoinm",
         "binanceusdm",

--- a/packages/oracle-node/manifests/data-services/primary.json
+++ b/packages/oracle-node/manifests/data-services/primary.json
@@ -88,6 +88,7 @@
       "source": [
         "ascendex",
         "bequant",
+        "binance-websocket",
         "binance",
         "binancecoinm",
         "binanceusdm",

--- a/packages/oracle-node/src/fetchers/BaseFetcher.ts
+++ b/packages/oracle-node/src/fetchers/BaseFetcher.ts
@@ -10,6 +10,7 @@ import {
 import { RedstoneCommon } from "@redstone-finance/utils";
 import createLogger from "../utils/logger";
 import { isDefined } from "../utils/objects";
+import { WebSocketFetcher } from "./WebSocketFetcher";
 
 const MAX_RESPONSE_TIME_TO_RETRY_FETCHING_MS = 3000;
 export type ExtractPricePairFn<T> = (item: T) => {
@@ -21,10 +22,16 @@ export abstract class BaseFetcher implements Fetcher {
   protected name: string;
   protected logger: Consola;
   protected retryForInvalidResponse: boolean = false;
+  protected webSocketFetcher?: WebSocketFetcher;
 
-  protected constructor(name: string) {
+  protected constructor(name: string, wsUrl?: string, pingIntervalMs?: number) {
     this.name = name;
     this.logger = createLogger("fetchers/" + name);
+    if (wsUrl && pingIntervalMs) {
+      this.webSocketFetcher = new WebSocketFetcher(wsUrl, pingIntervalMs);
+      this.setupListeners();
+      this.webSocketFetcher.connect();
+    }
   }
 
   // All the abstract methods below must be implemented in fetchers
@@ -34,6 +41,7 @@ export abstract class BaseFetcher implements Fetcher {
     ids?: string[],
     opts?: FetcherOpts
   ): PricesObjWithMetadata | PricesObj;
+  getSymbols?(): string[];
 
   // This method may be overridden to extend validation
   // eslint-disable-next-line @typescript-eslint/class-methods-use-this
@@ -50,13 +58,64 @@ export abstract class BaseFetcher implements Fetcher {
     return JSON.stringify(response);
   }
 
+  private setupListeners() {
+    if (!this.webSocketFetcher) return;
+
+    this.webSocketFetcher.on("open", () => {
+      if (this.getSymbols) {
+        const symbols = this.getSymbols();
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        this.fetchData(symbols);
+      }
+    });
+  }
+
   async fetchAll(
     symbols: string[],
     opts?: FetcherOpts
   ): Promise<PriceDataFetched[]> {
-    // Fetching data
     const fetchStartTime = Date.now();
     const ids = symbols.map((symbol) => this.convertSymbolToId(symbol));
+
+    // Initialize an empty PricesObjWithMetadata
+    const pricesObj: PricesObjWithMetadata | PricesObj = {};
+    // Fetch data via WebSocket if available
+    if (this.webSocketFetcher) {
+      this.logger.info("webSocketFetcher is available");
+      const WsPricesObj = await this.webSocketFetchAll(ids, opts);
+      Object.assign(pricesObj, WsPricesObj);
+    }
+
+    // Fetch data via HTTP
+    else {
+      const httpPricesObj = await this.httpFetchAll(ids, fetchStartTime, opts);
+      Object.assign(pricesObj, httpPricesObj);
+    }
+
+    return this.convertPricesObjToResultPriceArray(pricesObj, ids);
+  }
+
+  private webSocketFetchAll = async (
+    ids: string[],
+    opts?: FetcherOpts
+  ): Promise<PricesObjWithMetadata | PricesObj> => {
+    const pricesObj: PricesObjWithMetadata | PricesObj = {};
+    await this.fetchData(ids, opts);
+    this.webSocketFetcher?.on("data", (data) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-argument
+      const response = JSON.parse(data);
+      const prices = this.extractPrices(response);
+      Object.assign(pricesObj, prices);
+    });
+
+    return pricesObj;
+  };
+
+  private httpFetchAll = async (
+    ids: string[],
+    fetchStartTime: number,
+    opts?: FetcherOpts
+  ): Promise<PricesObjWithMetadata | PricesObj> => {
     let response = await this.fetchData(ids, opts);
 
     // Retrying data fetching if needed
@@ -78,10 +137,8 @@ export abstract class BaseFetcher implements Fetcher {
     }
 
     // Extracting prices from response
-    const pricesObj = this.extractPrices(response, ids, opts);
-
-    return this.convertPricesObjToResultPriceArray(pricesObj, ids);
-  }
+    return this.extractPrices(response, ids, opts);
+  };
 
   // This method converts internal asset id (asset identifier on fetcher level)
   // to an asset symbol (asset identifier on manifest level)
@@ -151,7 +208,6 @@ export abstract class BaseFetcher implements Fetcher {
         }
 
         if (isDefined(pricesObj[pricePair.id])) {
-          // case were same id is extracted more than once
           continue;
         }
 

--- a/packages/oracle-node/src/fetchers/WebSocketFetcher.ts
+++ b/packages/oracle-node/src/fetchers/WebSocketFetcher.ts
@@ -1,0 +1,105 @@
+import WebSocket from "ws";
+import { EventEmitter } from "events";
+import { stringifyData } from "../utils/objects";
+
+interface WebSocketMessage {
+  id: string;
+  method: string;
+  params: unknown;
+}
+
+export class WebSocketFetcher extends EventEmitter {
+  private ws?: WebSocket;
+  private pingInterval?: NodeJS.Timeout;
+  private reconnectTimeout?: NodeJS.Timeout;
+  private readonly reconnectDelay = 5000;
+
+  constructor(
+    private url: string,
+    private pingIntervalMs: number
+  ) {
+    super();
+  }
+
+  connect() {
+    this.ws = new WebSocket(this.url);
+
+    this.ws.on("open", this.handleOpen.bind(this));
+    this.ws.on("message", this.handleMessage.bind(this));
+    this.ws.on("error", this.handleError.bind(this));
+    this.ws.on("close", this.handleClose.bind(this));
+  }
+
+  private handleOpen() {
+    console.log("WebSocket connection opened for", this.url);
+    this.emit("open");
+    this.startPing();
+  }
+
+  private handleMessage(data: WebSocket.Data) {
+    const message = stringifyData(data);
+    console.log("WebSocket message received:", message);
+    this.emit("data", message);
+  }
+
+  private handleError(error: Error) {
+    console.error("WebSocket error:", error);
+    this.emit("error", error);
+  }
+
+  private handleClose() {
+    console.log("WebSocket connection closed");
+    this.emit("close");
+    this.stopPing();
+    this.scheduleReconnect();
+  }
+
+  private startPing() {
+    this.stopPing(); // Clear any existing intervals
+    this.pingInterval = setInterval(() => {
+      if (this.ws?.readyState === WebSocket.OPEN) {
+        this.ws.ping();
+      }
+    }, this.pingIntervalMs);
+  }
+
+  private stopPing() {
+    if (this.pingInterval) {
+      clearInterval(this.pingInterval);
+      this.pingInterval = undefined;
+    }
+  }
+
+  private scheduleReconnect() {
+    this.stopReconnect(); // Clear any existing timeout
+    this.reconnectTimeout = setTimeout(() => {
+      console.log("Reconnecting WebSocket...");
+      this.connect();
+    }, this.reconnectDelay);
+  }
+
+  private stopReconnect() {
+    if (this.reconnectTimeout) {
+      clearTimeout(this.reconnectTimeout);
+      this.reconnectTimeout = undefined;
+    }
+  }
+
+  sendMessage(message: WebSocketMessage) {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      console.log("Sending WebSocket message: ", message);
+      this.ws.send(JSON.stringify(message));
+    } else {
+      console.error("WebSocket is not open. Ready state:", this.ws?.readyState);
+    }
+  }
+
+  close() {
+    this.stopPing();
+    this.stopReconnect();
+    if (this.ws) {
+      this.ws.close();
+      this.ws.removeAllListeners();
+    }
+  }
+}

--- a/packages/oracle-node/src/fetchers/binance/BinanceFetcher.ts
+++ b/packages/oracle-node/src/fetchers/binance/BinanceFetcher.ts
@@ -1,0 +1,65 @@
+import { BaseFetcher } from "../BaseFetcher";
+import { PricesObjWithMetadata } from "../../types";
+import { v4 } from "uuid";
+
+const BINANCE_WS_URL = "wss://ws-api.binance.com:443/ws-api/v3";
+const BINANCE_PING_INTERVAL_MS = 3 * 60 * 1000;
+const symbols = ["btcusdt", "ethusdt", "bnbusdt"];
+
+type BinanceWebSocketMessage = {
+  id: string;
+  method: string;
+  params: { symbols: string[] };
+};
+
+type Result = {
+  symbol: string;
+  price: string;
+};
+
+type Response = {
+  result: Result[];
+};
+
+export class BinanceFetcher extends BaseFetcher {
+  constructor() {
+    super("binance-websocket", BINANCE_WS_URL, BINANCE_PING_INTERVAL_MS);
+    if (this.webSocketFetcher) {
+      this.webSocketFetcher.connect();
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  override async fetchData(): Promise<void> {
+    if (this.webSocketFetcher) {
+      this.webSocketFetcher.on("open", () => {
+        const message: BinanceWebSocketMessage = {
+          id: v4(),
+          method: "ticker.price",
+          params: { symbols: symbols.map((symbol) => symbol.toUpperCase()) },
+        };
+        this.webSocketFetcher?.sendMessage(message);
+      });
+    }
+  }
+
+  override extractPrices(data: Response): PricesObjWithMetadata {
+    const pricesObj: PricesObjWithMetadata = {};
+
+    data.result.forEach((result) => {
+      const price = parseFloat(result.price);
+      const symbol = result.symbol;
+
+      pricesObj[symbol] = {
+        value: price,
+        metadata: undefined,
+      };
+    });
+
+    return pricesObj;
+  }
+
+  override getSymbols(): string[] {
+    return symbols;
+  }
+}

--- a/packages/oracle-node/src/fetchers/index.ts
+++ b/packages/oracle-node/src/fetchers/index.ts
@@ -43,10 +43,12 @@ import { camelotV3Fetchers } from "./evm-chain/arbitrum/camelot-v3/all-camelot-v
 import pancakeSwapFetchers from "./evm-chain/ethereum/pancake-swap-on-chain/all-pancake-swap-fetchers";
 import { WombatFetcher } from "./wombat/WombatFetcher";
 import { apiFetchers } from "./api-fetcher/all-api-fetchers";
+import { BinanceFetcher } from "./binance/BinanceFetcher";
 
 export default {
   "yf-unofficial": new YfUnofficialFetcher(),
   "custom-urls": new CustomUrlsFetcher(),
+  "binance-websocket": new BinanceFetcher(),
   mock: new MockFetcher(),
   coingecko: new CoingeckoFetcher(),
   drand: new DrandFetcher(),

--- a/packages/oracle-node/src/utils/objects.ts
+++ b/packages/oracle-node/src/utils/objects.ts
@@ -1,4 +1,5 @@
 import fs from "fs";
+import WebSocket from "ws";
 
 export function mergeObjects<T = unknown>(objects: Array<unknown>) {
   return Object.assign({}, ...objects) as T;
@@ -29,4 +30,10 @@ export function getRequiredPropValue<T = unknown>(
 
 export function isDefined(value: unknown) {
   return value !== null && value !== undefined;
+}
+
+export function stringifyData(message: WebSocket.Data): string {
+  return typeof message === "object"
+    ? JSON.stringify(message)
+    : message.toString();
 }

--- a/packages/oracle-node/test/fetchers/websocket-fetcher.spec.ts
+++ b/packages/oracle-node/test/fetchers/websocket-fetcher.spec.ts
@@ -1,0 +1,129 @@
+import { WebSocketFetcher } from "../../src/fetchers/WebSocketFetcher";
+import WebSocket from "ws";
+import { EventEmitter } from "events";
+interface MockWebSocket {
+  on: jest.Mock;
+  emit: jest.Mock;
+  send: jest.Mock;
+  close: jest.Mock;
+  removeAllListeners?: jest.Mock;
+  readyState?: number;
+}
+
+type Call = [string, jest.Mock];
+jest.mock("ws");
+
+describe("WebSocketFetcher", () => {
+  let fetcher: WebSocketFetcher;
+  let mockWsInstance: MockWebSocket;
+  let calls: Call[];
+  const url = "ws://example.com";
+  const pingIntervalMs = 10000;
+
+  beforeEach(() => {
+    fetcher = new WebSocketFetcher(url, pingIntervalMs);
+    mockWsInstance = {
+      on: jest.fn(),
+      emit: jest.fn(),
+      send: jest.fn(),
+      close: jest.fn(),
+      removeAllListeners: jest.fn(),
+      readyState: WebSocket.CLOSED,
+    };
+    (WebSocket as unknown as jest.Mock).mockImplementation(
+      () => mockWsInstance
+    );
+    calls = mockWsInstance.on.mock.calls as unknown as Call[];
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should initialize correctly", () => {
+    expect(fetcher).toBeInstanceOf(EventEmitter);
+  });
+
+  it("should connect to WebSocket", () => {
+    fetcher.connect();
+    expect(WebSocket).toHaveBeenCalledWith(url);
+  });
+  it("should handle open event", () => {
+    const emitSpy = jest.spyOn(fetcher, "emit");
+    fetcher.connect();
+
+    const openHandler = calls.find((call) => call[0] === "open")?.[1];
+
+    if (openHandler) {
+      openHandler();
+    }
+
+    expect(emitSpy).toHaveBeenCalledWith("open");
+  });
+  it("should handle message event", () => {
+    const emitSpy = jest.spyOn(fetcher, "emit");
+    fetcher.connect();
+
+    const messageHandler = calls.find((call) => call[0] === "message")?.[1];
+    const data = JSON.stringify({ id: "1", method: "test", params: {} });
+    if (messageHandler) {
+      messageHandler(data);
+    }
+
+    expect(emitSpy).toHaveBeenCalledWith("data", data);
+  });
+
+  it("should handle error event", () => {
+    const emitSpy = jest.spyOn(fetcher, "emit");
+    fetcher.connect();
+
+    const errorHandler = calls.find((call) => call[0] === "error")?.[1];
+    const error = new Error("Test error");
+    if (errorHandler) {
+      try {
+        errorHandler(error);
+      } catch (e) {
+        console.error(e);
+      }
+    }
+    expect(emitSpy).toHaveBeenCalledWith("error", error);
+  });
+
+  it("should handle close event", () => {
+    const emitSpy = jest.spyOn(fetcher, "emit");
+    fetcher.connect();
+
+    const closeHandler = calls.find((call) => call[0] === "close")?.[1];
+    if (closeHandler) {
+      closeHandler();
+    }
+
+    expect(emitSpy).toHaveBeenCalledWith("close");
+  });
+
+  it("should send message when WebSocket is open", () => {
+    mockWsInstance.readyState = WebSocket.OPEN;
+
+    const message = { id: "1", method: "test", params: {} };
+    fetcher.connect();
+    fetcher.sendMessage(message);
+
+    expect(mockWsInstance.send).toHaveBeenCalledWith(JSON.stringify(message));
+  });
+
+  it("should not send message when WebSocket is not open", () => {
+    const message = { id: "1", method: "test", params: {} };
+    fetcher.connect();
+    fetcher.sendMessage(message);
+
+    expect(mockWsInstance.send).not.toHaveBeenCalled();
+  });
+
+  it("should close WebSocket connection", () => {
+    fetcher.connect();
+    fetcher.close();
+
+    expect(mockWsInstance.close).toHaveBeenCalled();
+    expect(mockWsInstance.removeAllListeners).toHaveBeenCalled(); // Ensure removeAllListeners is called
+  });
+});


### PR DESCRIPTION
BaseFetcher's websocket handling capabilities are introduced in my implementation. It uses the same abstract method, **fetchData**, to fetch all data for both HTTP and WS. I have moved the web socket features to **WebsocketFetcher**, where you can find all the necessary logic. 

We must set the following variables in order for the solution to function for Binance: const symbols = ["btcusdt", "ethusdt", "bnbusdt"]; as required by the environment; const BINANCE_WS_URL = "wss://ws-api.binance.com:443/ws-api/v3"; const BINANCE_PING_INTERVAL_MS = 3 * 60 * 1000. It can be stored in config or.env instead of being hardcoded in BinanceFetcher.

The implementation is covered by unit tests using WebSocketFetcher and BaseFetcher.